### PR TITLE
Feature/vdx 120 presentation definition

### DIFF
--- a/src/main/AuthenticationRequest.ts
+++ b/src/main/AuthenticationRequest.ts
@@ -122,7 +122,6 @@ async function createURIFromJWT(
   const schema = 'openid://';
   // Only used to validate if it contains a definition
   await PresentationExchange.findValidPresentationDefinitions(requestPayload);
-
   const query = Encodings.encodeJsonAsURI(requestPayload);
 
   switch (requestOpts.requestBy?.type) {

--- a/src/main/AuthenticationRequest.ts
+++ b/src/main/AuthenticationRequest.ts
@@ -56,8 +56,8 @@ export default class AuthenticationRequest {
     };
   }
 
-  static wrapAsURI(request: SIOP.AuthenticationRequestWithJWT): SIOP.AuthenticationRequestURI {
-    return createURIFromJWT(request.opts, request.payload, request.jwt);
+  static async wrapAsURI(request: SIOP.AuthenticationRequestWithJWT): Promise<SIOP.AuthenticationRequestURI> {
+    return await createURIFromJWT(request.opts, request.payload, request.jwt);
   }
 
   /**
@@ -90,7 +90,7 @@ export default class AuthenticationRequest {
     if (!verifiedJWT || !verifiedJWT.payload) {
       throw Error(SIOPErrors.ERROR_VERIFYING_SIGNATURE);
     }
-    const presentationDefinitions = PresentationExchange.findValidPresentationDefinitions(payload);
+    const presentationDefinitions = await PresentationExchange.findValidPresentationDefinitions(payload);
     return {
       ...verifiedJWT,
       verifyOpts: opts,
@@ -114,14 +114,14 @@ export default class AuthenticationRequest {
  * @param requestPayload
  * @param jwt
  */
-function createURIFromJWT(
+async function createURIFromJWT(
   requestOpts: SIOP.AuthenticationRequestOpts,
   requestPayload: SIOP.AuthenticationRequestPayload,
   jwt: string
-): SIOP.AuthenticationRequestURI {
+): Promise<SIOP.AuthenticationRequestURI> {
   const schema = 'openid://';
   // Only used to validate if it contains a definition
-  PresentationExchange.findValidPresentationDefinitions(requestPayload);
+  await PresentationExchange.findValidPresentationDefinitions(requestPayload);
 
   const query = Encodings.encodeJsonAsURI(requestPayload);
 

--- a/src/main/AuthenticationResponse.ts
+++ b/src/main/AuthenticationResponse.ts
@@ -283,7 +283,7 @@ async function assertValidVerifiablePresentations(definitions: PresentationDefin
 
   /*console.log('pd:', JSON.stringify(definitions));
   console.log('vps:', JSON.stringify(presentationPayloads));*/
-  if (definitions && !presentationPayloads) {
+  if (definitions && definitions.length && !presentationPayloads) {
     throw new Error(SIOPErrors.AUTH_REQUEST_EXPECTS_VP);
   } else if (!definitions && presentationPayloads) {
     throw new Error(SIOPErrors.AUTH_REQUEST_DOESNT_EXPECT_VP);

--- a/src/main/AuthenticationResponse.ts
+++ b/src/main/AuthenticationResponse.ts
@@ -267,7 +267,7 @@ async function assertValidVerifiablePresentations(definitions: PresentationDefin
   }
 
   // const definitions: PresentationDefinitionWithLocation[] = verifyOpts?.claims?.presentationDefinitions;
-  PresentationExchange.assertValidPresentationDefintionWithLocations(definitions);
+  PresentationExchange.assertValidPresentationDefinitionWithLocations(definitions);
   let presentationPayloads: VerifiablePresentationPayload[];
 
   if (verPayload.verifiable_presentations && verPayload.verifiable_presentations.length > 0) {

--- a/src/main/PresentationExchange.ts
+++ b/src/main/PresentationExchange.ts
@@ -51,8 +51,6 @@ export class PresentationExchange {
     }
 
     function sign(params: PresentationSignCallBackParams): Promise<IVerifiablePresentation> {
-      // console.log('##### SIGN CALLBACK IMPLEMENTATION NEEDED FOR VP');
-      // console.log(params);
       return Promise.resolve(params.presentation as IVerifiablePresentation);
     }
 
@@ -191,7 +189,6 @@ export class PresentationExchange {
         const pd: PresentationDefinitionV1 | PresentationDefinitionV2 = (await getWithUrl(definitionRef[0].value)) as unknown as
           | PresentationDefinitionV1
           | PresentationDefinitionV2;
-        console.log(JSON.stringify(pd));
         allDefinitions = handleAddingSinglePDInIdToken(pd, allDefinitions);
       }
     }

--- a/src/main/functions/HttpUtils.ts
+++ b/src/main/functions/HttpUtils.ts
@@ -43,3 +43,17 @@ export async function postAuthenticationResponseJwt(url: string, jwt: string): P
     throw new Error(`${(error as Error).message}`);
   }
 }
+
+export async function getWithUrl(url: string): Promise<Response> {
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+    });
+    if (!response || !response.status || (response.status !== 200 && response.status !== 201)) {
+      throw new Error(`${SIOPErrors.RESPONSE_STATUS_UNEXPECTED} ${response.status}:${response.statusText}, ${await response.json()}`);
+    }
+    return response;
+  } catch (error) {
+    throw new Error(`${(error as Error).message}`);
+  }
+}

--- a/src/main/functions/HttpUtils.ts
+++ b/src/main/functions/HttpUtils.ts
@@ -45,15 +45,14 @@ export async function postAuthenticationResponseJwt(url: string, jwt: string): P
 }
 
 export async function getWithUrl(url: string): Promise<Response> {
-  try {
-    const response = await fetch(url, {
-      method: 'GET',
+  return fetch(url)
+    .then((response: Response) => {
+      if (response.status >= 400) {
+        return Promise.reject(Error(`${SIOPErrors.RESPONSE_STATUS_UNEXPECTED} ${response.status}:${response.statusText} URL: ${url}`));
+      }
+      return response.json();
+    })
+    .catch((e) => {
+      return Promise.reject(Error(`${(e as Error).message}`));
     });
-    if (!response || !response.status || (response.status !== 200 && response.status !== 201)) {
-      throw new Error(`${SIOPErrors.RESPONSE_STATUS_UNEXPECTED} ${response.status}:${response.statusText}, ${await response.json()}`);
-    }
-    return response;
-  } catch (error) {
-    throw new Error(`${(error as Error).message}`);
-  }
 }

--- a/src/main/types/Errors.ts
+++ b/src/main/types/Errors.ts
@@ -36,7 +36,7 @@ enum SIOPErrors {
   NO_SELFISSUED_ISS = 'The Response Token Issuer Claim (iss) MUST be https://self-isued.me',
   NO_SUB_TYPE = 'No or empty sub_type found in JWT payload',
   REGISTRATION_NOT_SET = 'Registration metadata not set.',
-  REQUEST_CLAIMS_CANT_SEND_PRESENTATION_DEFINITION_BY_RE_AND_VAL = "Request claims can't have both 'presentation_definition' and 'presentation_definition_uri'",
+  REQUEST_CLAIMS_PRESENTATION_DEFINITION_BY_REF_AND_VALUE_NON_EXCLUSIVE = "Request claims can't have both 'presentation_definition' and 'presentation_definition_uri'",
   REQUEST_CLAIMS_PRESENTATION_DEFINITION_NOT_VALID = 'Presentation definition in the request claims is not valid',
   REQUEST_OBJECT_TYPE_NOT_SET = 'Request object type is not set.',
   RESPONSE_AUD_MISMATCH_REDIRECT_URI = 'The audience (aud) in Response Token does NOT match the redirect_uri value sent in the Authentication Request',

--- a/src/main/types/Errors.ts
+++ b/src/main/types/Errors.ts
@@ -36,6 +36,7 @@ enum SIOPErrors {
   NO_SELFISSUED_ISS = 'The Response Token Issuer Claim (iss) MUST be https://self-isued.me',
   NO_SUB_TYPE = 'No or empty sub_type found in JWT payload',
   REGISTRATION_NOT_SET = 'Registration metadata not set.',
+  REQUEST_CLAIMS_CANT_SEND_PRESENTATION_DEFINITION_BY_RE_AND_VAL = "Request claims can't have both 'presentation_definition' and 'presentation_definition_uri'",
   REQUEST_CLAIMS_PRESENTATION_DEFINITION_NOT_VALID = 'Presentation definition in the request claims is not valid',
   REQUEST_OBJECT_TYPE_NOT_SET = 'Request object type is not set.',
   RESPONSE_AUD_MISMATCH_REDIRECT_URI = 'The audience (aud) in Response Token does NOT match the redirect_uri value sent in the Authentication Request',

--- a/src/main/types/SIOP.types.ts
+++ b/src/main/types/SIOP.types.ts
@@ -129,8 +129,6 @@ export interface IdTokenClaimPayload {
   [x: string]: unknown;
 }
 
-// A request MUST contain a presentation_definition or a presentation_definition_uri but both are mutually exclusive.
-//TODO: https://sphereon.atlassian.net/browse/VDX-120
 export interface VpTokenClaimPayload {
   response_type: string;
   presentation_definition?: PresentationDefinitionV1 | PresentationDefinitionV2;

--- a/test/IT.spec.ts
+++ b/test/IT.spec.ts
@@ -376,7 +376,7 @@ describe('RP and OP interaction should', () => {
     expect(verifiedAuthReqWithJWT.signer).toBeDefined();
     expect(verifiedAuthReqWithJWT.issuer).toMatch(rpMockEntity.did);
     const pex = new PresentationExchange({ did: HOLDER_DID, allVerifiableCredentials: getVCs() });
-    const pd: PresentationDefinitionWithLocation[] = PresentationExchange.findValidPresentationDefinitions(parsedAuthReqURI.requestPayload);
+    const pd: PresentationDefinitionWithLocation[] = await PresentationExchange.findValidPresentationDefinitions(parsedAuthReqURI.requestPayload);
     await pex.selectVerifiableCredentialsForSubmission(pd[0].definition);
     const vp = await pex.submissionFrom(pd[0].definition, getVCs());
     const authenticationResponseWithJWT = await op.createAuthenticationResponse(verifiedAuthReqWithJWT, {

--- a/test/PresentationExchange.spec.ts
+++ b/test/PresentationExchange.spec.ts
@@ -226,7 +226,6 @@ describe('presentation exchange manager tests', () => {
         },
       ],
     };
-    // console.log(JSON.stringify(response,null,2))
     nock('http://my_own_pd.com')
       .persist()
       .get(/pd/)
@@ -280,7 +279,6 @@ describe('presentation exchange manager tests', () => {
       type: ['VerifiablePresentation'],
       verifiableCredential: vcs,
     });
-    console.log(JSON.stringify(result));
     expect(result.errors.length).toBe(0);
     expect(result.value.definition_id).toBe('Insurance Plans');
   });


### PR DESCRIPTION
adding the pd ref ability
- in the previous version we could only send the value of a PD, this pr enables us to send a `presentation_definition_uri` instead. Note that you can't send both `presentation_definition` and `presentation_definition_uri` at the same time