### PR TITLE
Feature/vdx 137/handle subject syntax types

### DIFF
--- a/src/main/AuthenticationRequest.ts
+++ b/src/main/AuthenticationRequest.ts
@@ -275,7 +275,6 @@ function createClaimsPayload(opts: ClaimOpts, nonce: string): ClaimPayload {
           throw new Error(SIOPErrors.REQUEST_CLAIMS_PRESENTATION_DEFINITION_NOT_VALID);
         } else {
           vp_token = {
-            //TODO: nonce should be initialized correctly
             nonce: nonce,
             presentation_definition: def.definition,
             response_type: PresentationLocation.VP_TOKEN,

--- a/src/main/AuthenticationRequest.ts
+++ b/src/main/AuthenticationRequest.ts
@@ -134,6 +134,8 @@ export default class AuthenticationRequest {
     }
     if (opts.verification.checkLinkedDomain && opts.verification.checkLinkedDomain != CheckLinkedDomain.NEVER) {
       await validateLinkedDomainWithDid(verPayload.iss, opts.verification.checkLinkedDomain);
+    } else if (!opts.verification.checkLinkedDomain) {
+      await validateLinkedDomainWithDid(verPayload.iss, CheckLinkedDomain.IF_PRESENT);
     }
     const presentationDefinitions = await PresentationExchange.findValidPresentationDefinitions(payload);
     return {

--- a/src/main/AuthenticationRequest.ts
+++ b/src/main/AuthenticationRequest.ts
@@ -248,7 +248,7 @@ function assertValidRequestOpts(opts: AuthenticationRequestOpts) {
   assertValidRequestRegistrationOpts(opts.registration);
 }
 
-function createClaimsPayload(opts: ClaimOpts): ClaimPayload {
+function createClaimsPayload(opts: ClaimOpts, nonce: string): ClaimPayload {
   if (!opts || !opts.presentationDefinitions || opts.presentationDefinitions.length == 0) {
     return undefined;
   }
@@ -276,7 +276,7 @@ function createClaimsPayload(opts: ClaimOpts): ClaimPayload {
         } else {
           vp_token = {
             //TODO: nonce should be initialized correctly
-            nonce: 'NONCE_STRING',
+            nonce: nonce,
             presentation_definition: def.definition,
             response_type: PresentationLocation.VP_TOKEN,
           };
@@ -296,7 +296,7 @@ async function createAuthenticationRequestPayload(opts: AuthenticationRequestOpt
   assertValidRequestOpts(opts);
   const state = getState(opts.state);
   const registration = await createRequestRegistration(opts.registration);
-  const claims = createClaimsPayload(opts.claims);
+  const claims = createClaimsPayload(opts.claims, opts.nonce);
 
   return {
     response_type: ResponseType.ID_TOKEN,

--- a/src/main/AuthenticationRequestRegistration.ts
+++ b/src/main/AuthenticationRequestRegistration.ts
@@ -63,7 +63,7 @@ function createRPRegistrationMetadataPayload(opts: RPRegistrationMetadataOpts): 
     response_types_supported: opts.responseTypesSupported,
     scopes_supported: opts.scopesSupported,
     subject_types_supported: opts.subjectTypesSupported,
-    // TODO: https://sphereon.atlassian.net/browse/VDX-126 : supporting JSON Web Key (JWK) Thumbprint
+    // TODO: @Niels do we need the default did-methods?
     subject_syntax_types_supported: opts.subjectSyntaxTypesSupported || ['did:web:', 'did:ion:'],
     vp_formats: opts.vpFormatsSupported,
   };

--- a/src/main/AuthenticationRequestRegistration.ts
+++ b/src/main/AuthenticationRequestRegistration.ts
@@ -63,7 +63,6 @@ function createRPRegistrationMetadataPayload(opts: RPRegistrationMetadataOpts): 
     response_types_supported: opts.responseTypesSupported,
     scopes_supported: opts.scopesSupported,
     subject_types_supported: opts.subjectTypesSupported,
-    // TODO: @Niels do we need the default did-methods?
     subject_syntax_types_supported: opts.subjectSyntaxTypesSupported || ['did:web:', 'did:ion:'],
     vp_formats: opts.vpFormatsSupported,
   };

--- a/src/main/AuthenticationResponse.ts
+++ b/src/main/AuthenticationResponse.ts
@@ -247,6 +247,7 @@ async function createSIOPResponsePayload(
   const nonce = verifiedJwt.payload.nonce || resOpts.nonce || getNonce(state);
   const registration = createDiscoveryMetadataPayload(resOpts.registration);
 
+  //https://sphereon.atlassian.net/browse/VDX-140
   // *********************************************************************************
   // todo We are missing a wrapper object. Actually the current object is the id_token
   // *********************************************************************************

--- a/src/main/AuthenticationResponse.ts
+++ b/src/main/AuthenticationResponse.ts
@@ -130,6 +130,8 @@ export default class AuthenticationResponse {
     const issuerDid = getIssuerDidFromPayload(payload);
     if (verifyOpts.verification.checkLinkedDomain && verifyOpts.verification.checkLinkedDomain !== CheckLinkedDomain.NEVER) {
       await validateLinkedDomainWithDid(issuerDid, verifyOpts.verification.checkLinkedDomain);
+    } else if (!verifyOpts.verification.checkLinkedDomain) {
+      await validateLinkedDomainWithDid(issuerDid, CheckLinkedDomain.IF_PRESENT);
     }
     const verPayload = verifiedJWT.payload as AuthenticationResponsePayload;
     assertValidResponseJWT({ header, verPayload: verPayload, audience: verifyOpts.audience });

--- a/src/main/AuthenticationResponse.ts
+++ b/src/main/AuthenticationResponse.ts
@@ -269,7 +269,7 @@ async function createSIOPResponsePayload(
     vp_token,
     verifiable_presentations,
   };
-  if (!supportedDidMethods.length && !resOpts.did) {
+  if (supportedDidMethods.indexOf(SubjectSyntaxTypesSupportedValues.JWK_THUMBPRINT) != -1 && !resOpts.did) {
     const { thumbprint, subJwk } = await createThumbprintAndJWK(resOpts);
     authenticationResponsePayload.sub_jwk = subJwk;
     authenticationResponsePayload.sub = thumbprint;

--- a/src/main/AuthenticationResponse.ts
+++ b/src/main/AuthenticationResponse.ts
@@ -242,7 +242,7 @@ async function createSIOPResponsePayload(
   const supportedDidMethods = verifiedJwt.payload.registration?.subject_syntax_types_supported?.filter((sst) =>
     sst.includes(SubjectSyntaxTypesSupportedValues.DID.valueOf())
   );
-  const { thumbprint, subJwk } = await createThumbprintAndJWK(resOpts);
+
   const state = resOpts.state || getState(verifiedJwt.payload.state);
   const nonce = verifiedJwt.payload.nonce || resOpts.nonce || getNonce(state);
   const registration = createDiscoveryMetadataPayload(resOpts.registration);
@@ -255,7 +255,7 @@ async function createSIOPResponsePayload(
   const { verifiable_presentations, vp_token } = extractPresentations(resOpts);
   const authenticationResponsePayload: AuthenticationResponsePayload = {
     iss: ResponseIss.SELF_ISSUED_V2,
-    sub: supportedDidMethods.length && resOpts.did ? resOpts.did : thumbprint,
+    sub: resOpts.did,
     aud: verifiedJwt.payload.redirect_uri,
     did: resOpts.did,
     sub_type: supportedDidMethods.length && resOpts.did ? SubjectIdentifierType.DID : SubjectIdentifierType.JKT,
@@ -268,7 +268,9 @@ async function createSIOPResponsePayload(
     verifiable_presentations,
   };
   if (supportedDidMethods.length && resOpts.did) {
+    const { thumbprint, subJwk } = await createThumbprintAndJWK(resOpts);
     authenticationResponsePayload.sub_jwk = subJwk;
+    authenticationResponsePayload.sub = thumbprint;
   }
   return authenticationResponsePayload;
 }

--- a/src/main/AuthenticationResponse.ts
+++ b/src/main/AuthenticationResponse.ts
@@ -253,14 +253,12 @@ async function createSIOPResponsePayload(
   // *********************************************************************************
 
   const { verifiable_presentations, vp_token } = extractPresentations(resOpts);
-  return {
+  const authenticationResponsePayload: AuthenticationResponsePayload = {
     iss: ResponseIss.SELF_ISSUED_V2,
     sub: supportedDidMethods.length && resOpts.did ? resOpts.did : thumbprint,
     aud: verifiedJwt.payload.redirect_uri,
     did: resOpts.did,
     sub_type: supportedDidMethods.length && resOpts.did ? SubjectIdentifierType.DID : SubjectIdentifierType.JKT,
-    //FIXME: @Niels I'm not sure about this, but since we don't want jwk if we're supporting any did method, this seemed right.
-    sub_jwk: supportedDidMethods.length && resOpts.did ? undefined : subJwk,
     state,
     nonce,
     iat: Date.now() / 1000,
@@ -269,6 +267,10 @@ async function createSIOPResponsePayload(
     vp_token,
     verifiable_presentations,
   };
+  if (supportedDidMethods.length && resOpts.did) {
+    authenticationResponsePayload.sub_jwk = subJwk;
+  }
+  return authenticationResponsePayload;
 }
 
 function assertValidResponseOpts(opts: AuthenticationResponseOpts) {

--- a/src/main/AuthenticationResponse.ts
+++ b/src/main/AuthenticationResponse.ts
@@ -267,7 +267,7 @@ async function createSIOPResponsePayload(
     vp_token,
     verifiable_presentations,
   };
-  if (supportedDidMethods.length && resOpts.did) {
+  if (!supportedDidMethods.length && !resOpts.did) {
     const { thumbprint, subJwk } = await createThumbprintAndJWK(resOpts);
     authenticationResponsePayload.sub_jwk = subJwk;
     authenticationResponsePayload.sub = thumbprint;

--- a/src/main/OP.ts
+++ b/src/main/OP.ts
@@ -32,7 +32,7 @@ export class OP {
 
   public constructor(opts: { builder?: OPBuilder; responseOpts?: AuthenticationResponseOpts; verifyOpts?: VerifyAuthenticationRequestOpts }) {
     this._authResponseOpts = { ...createResponseOptsFromBuilderOrExistingOpts(opts) };
-    this._verifyAuthRequestOpts = { ...createVerifyRequestOptsFromBuilderOrExistingOpts(opts) } as Partial<VerifyAuthenticationRequestOpts>;
+    this._verifyAuthRequestOpts = { ...createVerifyRequestOptsFromBuilderOrExistingOpts(opts) };
   }
 
   get authResponseOpts(): AuthenticationResponseOpts {
@@ -221,7 +221,10 @@ function createResponseOptsFromBuilderOrExistingOpts(opts: { builder?: OPBuilder
   return responseOpts;
 }
 
-function createVerifyRequestOptsFromBuilderOrExistingOpts(opts: { builder?: OPBuilder; verifyOpts?: Partial<VerifyAuthenticationRequestOpts> }) {
+function createVerifyRequestOptsFromBuilderOrExistingOpts(opts: {
+  builder?: OPBuilder;
+  verifyOpts?: VerifyAuthenticationRequestOpts;
+}): VerifyAuthenticationRequestOpts {
   const subjectSyntaxTypesSupported = [];
   if (opts.builder?.responseRegistration?.subjectSyntaxTypesSupported) {
     if (Array.isArray(opts.builder.responseRegistration.subjectSyntaxTypesSupported)) {
@@ -251,7 +254,7 @@ function createVerifyRequestOptsFromBuilderOrExistingOpts(opts: { builder?: OPBu
                 ? opts.builder.resolvers
                 : getResolver({ subjectSyntaxTypesSupported: subjectSyntaxTypesSupported }),
           },
-        },
+        } as InternalVerification,
       }
     : opts.verifyOpts;
 }

--- a/src/main/OP.ts
+++ b/src/main/OP.ts
@@ -4,7 +4,7 @@ import fetch from 'cross-fetch';
 import AuthenticationRequest from './AuthenticationRequest';
 import AuthenticationResponse from './AuthenticationResponse';
 import OPBuilder from './OPBuilder';
-import { getResolver, postAuthenticationResponse, postAuthenticationResponseJwt } from './functions';
+import { getResolver, postAuthenticationResponse, postAuthenticationResponseJwt, toSIOPRegistrationDidMethod } from './functions';
 import { AuthenticationResponseOptsSchema } from './schemas';
 import {
   AuthenticationResponseOpts,
@@ -160,7 +160,7 @@ function createResponseOptsFromBuilderOrExistingOpts(opts: { builder?: OPBuilder
     }
     const unionSubjectSyntaxTypes = new Set();
     opts.builder.responseRegistration.subjectSyntaxTypesSupported.forEach((sst) => unionSubjectSyntaxTypes.add(sst));
-    opts.builder.didMethods.forEach((sst) => unionSubjectSyntaxTypes.add(sst));
+    opts.builder.didMethods.forEach((didMethod) => unionSubjectSyntaxTypes.add(toSIOPRegistrationDidMethod(didMethod)));
     opts.builder.responseRegistration.subjectSyntaxTypesSupported = Array.from(unionSubjectSyntaxTypes) as string[];
   }
   const responseOpts: AuthenticationResponseOpts = opts.builder
@@ -243,6 +243,7 @@ function createVerifyRequestOptsFromBuilderOrExistingOpts(opts: { builder?: OPBu
           checkLinkedDomain: opts.builder.checkLinkedDomain,
           resolveOpts: {
             subjectSyntaxTypesSupported: subjectSyntaxTypesSupported,
+            resolver: opts.builder.resolver,
             resolvers:
               //TODO: discuss this with Niels
               //https://sphereon.atlassian.net/browse/VDX-139

--- a/src/main/OP.ts
+++ b/src/main/OP.ts
@@ -245,6 +245,7 @@ function createVerifyRequestOptsFromBuilderOrExistingOpts(opts: { builder?: OPBu
             subjectSyntaxTypesSupported: subjectSyntaxTypesSupported,
             resolvers:
               //TODO: discuss this with Niels
+              //https://sphereon.atlassian.net/browse/VDX-139
               opts.builder.resolvers && opts.builder.resolvers.size
                 ? opts.builder.resolvers
                 : getResolver({ subjectSyntaxTypesSupported: subjectSyntaxTypesSupported }),

--- a/src/main/OP.ts
+++ b/src/main/OP.ts
@@ -233,7 +233,6 @@ function createVerifyRequestOptsFromBuilderOrExistingOpts(opts: { builder?: OPBu
           mode: VerificationMode.INTERNAL,
           checkLinkedDomain: opts.builder.checkLinkedDomain,
           resolveOpts: {
-            //TODO: https://sphereon.atlassian.net/browse/VDX-126 add support of other subjectSyntaxTypes
             subjectSyntaxTypesSupported: subjectSyntaxTypesSupported,
             resolver:
               opts.builder.resolvers && opts.builder.resolvers.size //TODO: discuss this with Niels

--- a/src/main/OP.ts
+++ b/src/main/OP.ts
@@ -154,6 +154,15 @@ async function parseAndResolveUri(encodedUri: string) {
 }
 
 function createResponseOptsFromBuilderOrExistingOpts(opts: { builder?: OPBuilder; responseOpts?: AuthenticationResponseOpts }) {
+  if (opts?.builder?.didMethods.length && opts.builder?.responseRegistration?.subjectSyntaxTypesSupported) {
+    if (!Array.isArray(opts.builder.responseRegistration.subjectSyntaxTypesSupported)) {
+      opts.builder.responseRegistration.subjectSyntaxTypesSupported = [opts.builder.responseRegistration.subjectSyntaxTypesSupported];
+    }
+    const unionSubjectSyntaxTypes = new Set();
+    opts.builder.responseRegistration.subjectSyntaxTypesSupported.forEach((sst) => unionSubjectSyntaxTypes.add(sst));
+    opts.builder.didMethods.forEach((sst) => unionSubjectSyntaxTypes.add(sst));
+    opts.builder.responseRegistration.subjectSyntaxTypesSupported = Array.from(unionSubjectSyntaxTypes) as string[];
+  }
   const responseOpts: AuthenticationResponseOpts = opts.builder
     ? {
         registration: {
@@ -234,9 +243,10 @@ function createVerifyRequestOptsFromBuilderOrExistingOpts(opts: { builder?: OPBu
           checkLinkedDomain: opts.builder.checkLinkedDomain,
           resolveOpts: {
             subjectSyntaxTypesSupported: subjectSyntaxTypesSupported,
-            resolver:
-              opts.builder.resolvers && opts.builder.resolvers.size //TODO: discuss this with Niels
-                ? getResolver({ resolver: opts.builder.resolvers.values().next().value })
+            resolvers:
+              //TODO: discuss this with Niels
+              opts.builder.resolvers && opts.builder.resolvers.size
+                ? opts.builder.resolvers
                 : getResolver({ subjectSyntaxTypesSupported: subjectSyntaxTypesSupported }),
           },
         },

--- a/src/main/OPBuilder.ts
+++ b/src/main/OPBuilder.ts
@@ -25,9 +25,11 @@ export default class OPBuilder {
   resolver?: Resolvable;
   signatureType: InternalSignature | ExternalSignature | SuppliedSignature;
   checkLinkedDomain?: CheckLinkedDomain;
+  didMethods: string[] = [];
 
   addDidMethod(didMethod: string, opts?: { resolveUrl?: string; baseUrl?: string }): OPBuilder {
     this.addResolver(didMethod, new Resolver(getUniResolver(getMethodFromDid(didMethod), { ...opts })));
+    this.didMethods.push(didMethod);
     return this;
   }
 

--- a/src/main/OPBuilder.ts
+++ b/src/main/OPBuilder.ts
@@ -28,8 +28,13 @@ export default class OPBuilder {
   didMethods: string[] = [];
 
   addDidMethod(didMethod: string, opts?: { resolveUrl?: string; baseUrl?: string }): OPBuilder {
-    this.addResolver(didMethod, new Resolver(getUniResolver(getMethodFromDid(didMethod), { ...opts })));
-    this.didMethods.push(didMethod);
+    if (didMethod.startsWith('did:')) {
+      this.addResolver(getMethodFromDid(didMethod), new Resolver(getUniResolver(getMethodFromDid(didMethod), { ...opts })));
+      this.didMethods.push(getMethodFromDid(didMethod));
+    } else {
+      this.addResolver(didMethod, new Resolver(getUniResolver(didMethod, { ...opts })));
+      this.didMethods.push(didMethod);
+    }
     return this;
   }
 

--- a/src/main/RP.ts
+++ b/src/main/RP.ts
@@ -119,6 +119,15 @@ function createRequestOptsFromBuilderOrExistingOpts(opts: { builder?: RPBuilder;
 }
 
 function createVerifyResponseOptsFromBuilderOrExistingOpts(opts: { builder?: RPBuilder; verifyOpts?: Partial<VerifyAuthenticationResponseOpts> }) {
+  if (opts?.builder?.didMethods.length && opts.builder?.requestRegistration?.subjectSyntaxTypesSupported) {
+    if (!Array.isArray(opts.builder.requestRegistration.subjectSyntaxTypesSupported)) {
+      opts.builder.requestRegistration.subjectSyntaxTypesSupported = [opts.builder.requestRegistration.subjectSyntaxTypesSupported];
+    }
+    const unionSubjectSyntaxTypes = new Set();
+    opts.builder.requestRegistration.subjectSyntaxTypesSupported.forEach((sst) => unionSubjectSyntaxTypes.add(sst));
+    opts.builder.didMethods.forEach((sst) => unionSubjectSyntaxTypes.add(sst));
+    opts.builder.requestRegistration.subjectSyntaxTypesSupported = Array.from(unionSubjectSyntaxTypes) as string[];
+  }
   return opts.builder
     ? {
         verification: {
@@ -128,9 +137,10 @@ function createVerifyResponseOptsFromBuilderOrExistingOpts(opts: { builder?: RPB
             subjectSyntaxTypesSupported: !opts.builder.requestRegistration.subjectSyntaxTypesSupported
               ? []
               : opts.builder.requestRegistration.subjectSyntaxTypesSupported,
-            resolver:
-              opts.builder.resolvers && opts.builder.resolvers.size //TODO: discuss this with Niels
-                ? getResolver({ resolver: opts.builder.resolvers.values().next().value })
+            resolvers:
+              //TODO: discuss this with Niels
+              opts.builder.resolvers && opts.builder.resolvers.size
+                ? opts.builder.resolvers
                 : getResolver({ subjectSyntaxTypesSupported: opts.builder.requestRegistration.subjectSyntaxTypesSupported }),
           },
         },

--- a/src/main/RP.ts
+++ b/src/main/RP.ts
@@ -125,7 +125,6 @@ function createVerifyResponseOptsFromBuilderOrExistingOpts(opts: { builder?: RPB
           mode: VerificationMode.INTERNAL,
           checkLinkedDomain: opts.builder.checkLinkedDomain,
           resolveOpts: {
-            //TODO: https://sphereon.atlassian.net/browse/VDX-126 add support of other subjectSyntaxTypes
             subjectSyntaxTypesSupported: !opts.builder.requestRegistration.subjectSyntaxTypesSupported
               ? []
               : opts.builder.requestRegistration.subjectSyntaxTypesSupported,

--- a/src/main/RP.ts
+++ b/src/main/RP.ts
@@ -139,6 +139,7 @@ function createVerifyResponseOptsFromBuilderOrExistingOpts(opts: { builder?: RPB
               : opts.builder.requestRegistration.subjectSyntaxTypesSupported,
             resolvers:
               //TODO: discuss this with Niels
+              //https://sphereon.atlassian.net/browse/VDX-139
               opts.builder.resolvers && opts.builder.resolvers.size
                 ? opts.builder.resolvers
                 : getResolver({ subjectSyntaxTypesSupported: opts.builder.requestRegistration.subjectSyntaxTypesSupported }),

--- a/src/main/RP.ts
+++ b/src/main/RP.ts
@@ -126,13 +126,13 @@ function createVerifyResponseOptsFromBuilderOrExistingOpts(opts: { builder?: RPB
           checkLinkedDomain: opts.builder.checkLinkedDomain,
           resolveOpts: {
             //TODO: https://sphereon.atlassian.net/browse/VDX-126 add support of other subjectSyntaxTypes
-            didMethods: !opts.builder.requestRegistration.subjectSyntaxTypesSupported
+            subjectSyntaxTypesSupported: !opts.builder.requestRegistration.subjectSyntaxTypesSupported
               ? []
-              : opts.builder.requestRegistration.subjectSyntaxTypesSupported.filter((t) => t.startsWith('did:')),
-            resolver: opts.builder.resolvers
-              ? //TODO: discuss this with Niels
-                getResolver({ resolver: opts.builder.resolvers.values().next().value })
-              : getResolver({ subjectSyntaxTypesSupported: opts.builder.requestRegistration.subjectSyntaxTypesSupported }),
+              : opts.builder.requestRegistration.subjectSyntaxTypesSupported,
+            resolver:
+              opts.builder.resolvers && opts.builder.resolvers.size //TODO: discuss this with Niels
+                ? getResolver({ resolver: opts.builder.resolvers.values().next().value })
+                : getResolver({ subjectSyntaxTypesSupported: opts.builder.requestRegistration.subjectSyntaxTypesSupported }),
           },
         },
       }

--- a/src/main/RPBuilder.ts
+++ b/src/main/RPBuilder.ts
@@ -66,8 +66,13 @@ export default class RPBuilder {
   }
 
   addDidMethod(didMethod: string, opts?: { resolveUrl?: string; baseUrl?: string }): RPBuilder {
-    this.addResolver(didMethod, new Resolver(getUniResolver(getMethodFromDid(didMethod), { ...opts })));
-    this.didMethods.push(didMethod);
+    if (didMethod.startsWith('did:')) {
+      this.addResolver(getMethodFromDid(didMethod), new Resolver(getUniResolver(getMethodFromDid(didMethod), { ...opts })));
+      this.didMethods.push(getMethodFromDid(didMethod));
+    } else {
+      this.addResolver(didMethod, new Resolver(getUniResolver(didMethod, { ...opts })));
+      this.didMethods.push(didMethod);
+    }
     return this;
   }
 

--- a/src/main/RPBuilder.ts
+++ b/src/main/RPBuilder.ts
@@ -33,7 +33,7 @@ export default class RPBuilder {
   responseContext?: ResponseContext.RP;
   claims?: ClaimOpts;
   checkLinkedDomain?: CheckLinkedDomain;
-
+  didMethods: string[] = [];
   // claims?: ClaimPayload;
 
   addIssuer(issuer: ResponseIss): RPBuilder {
@@ -67,6 +67,7 @@ export default class RPBuilder {
 
   addDidMethod(didMethod: string, opts?: { resolveUrl?: string; baseUrl?: string }): RPBuilder {
     this.addResolver(didMethod, new Resolver(getUniResolver(getMethodFromDid(didMethod), { ...opts })));
+    this.didMethods.push(didMethod);
     return this;
   }
 

--- a/src/main/functions/DIDResolution.ts
+++ b/src/main/functions/DIDResolution.ts
@@ -18,6 +18,9 @@ export function getResolver(opts: ResolveOpts): Resolvable {
   }[] = [];
   if (opts.subjectSyntaxTypesSupported.indexOf(SubjectIdentifierType.DID) === -1) {
     const specificDidMethods = opts.subjectSyntaxTypesSupported.filter((sst) => sst.includes('did:'));
+    if (!specificDidMethods.length) {
+      throw new Error(SIOPErrors.NO_DID_METHOD_FOUND);
+    }
     for (const didMethod of specificDidMethods) {
       const uniResolver = getUniResolver(getMethodFromDid(didMethod), { resolveUrl: opts.resolveUrl });
       uniResolvers.push(uniResolver);

--- a/src/main/functions/DidSiopMetadata.ts
+++ b/src/main/functions/DidSiopMetadata.ts
@@ -8,7 +8,6 @@ import {
   SubjectSyntaxTypesSupportedValues,
 } from '../types';
 
-//TODO, since syntax_types_Supported can contain non DIDs, fix it in the VDX-126
 export function assertValidMetadata(opMetadata: DiscoveryMetadataPayload, rpMetadata: RPRegistrationMetadataPayload): CommonSupportedMetadata {
   let subjectSyntaxTypesSupported = [];
   const credentials = supportedCredentialsFormats(rpMetadata.vp_formats, opMetadata.vp_formats);

--- a/src/main/functions/DidSiopMetadata.ts
+++ b/src/main/functions/DidSiopMetadata.ts
@@ -1,15 +1,21 @@
 import { Format } from '@sphereon/pex-models';
 
-import { CommonSupportedMetadata, DiscoveryMetadataPayload, RPRegistrationMetadataPayload, SIOPErrors, SubjectIdentifierType } from '../types';
+import {
+  CommonSupportedMetadata,
+  DiscoveryMetadataPayload,
+  RPRegistrationMetadataPayload,
+  SIOPErrors,
+  SubjectSyntaxTypesSupportedValues,
+} from '../types';
 
 //TODO, since syntax_types_Supported can contain non DIDs, fix it in the VDX-126
 export function assertValidMetadata(opMetadata: DiscoveryMetadataPayload, rpMetadata: RPRegistrationMetadataPayload): CommonSupportedMetadata {
   let subjectSyntaxTypesSupported = [];
   const credentials = supportedCredentialsFormats(rpMetadata.vp_formats, opMetadata.vp_formats);
-  const isDid = verifySubjectIdentifiers(rpMetadata.subject_syntax_types_supported);
-  if (isDid && rpMetadata.subject_syntax_types_supported) {
-    subjectSyntaxTypesSupported = supportedDidMethods(rpMetadata.subject_syntax_types_supported, opMetadata.subject_syntax_types_supported);
-  } else if (isDid && (!rpMetadata.subject_syntax_types_supported || !rpMetadata.subject_syntax_types_supported.length)) {
+  const isValidSubjectSyntax = verifySubjectSyntaxes(rpMetadata.subject_syntax_types_supported);
+  if (isValidSubjectSyntax && rpMetadata.subject_syntax_types_supported) {
+    subjectSyntaxTypesSupported = supportedSubjectSyntaxTypes(rpMetadata.subject_syntax_types_supported, opMetadata.subject_syntax_types_supported);
+  } else if (isValidSubjectSyntax && (!rpMetadata.subject_syntax_types_supported || !rpMetadata.subject_syntax_types_supported.length)) {
     if (opMetadata.subject_syntax_types_supported || opMetadata.subject_syntax_types_supported.length) {
       subjectSyntaxTypesSupported = [...opMetadata.subject_syntax_types_supported];
     }
@@ -32,21 +38,50 @@ function getIntersection<T>(rpMetadata: Array<T> | T, opMetadata: Array<T> | T):
   return arrayA.filter((value) => arrayB.includes(value));
 }
 
-function verifySubjectIdentifiers(subjectSyntaxTypesSupported: string[]): boolean {
+function verifySubjectSyntaxes(subjectSyntaxTypesSupported: string[]): boolean {
   if (subjectSyntaxTypesSupported.length) {
     if (Array.isArray(subjectSyntaxTypesSupported)) {
-      return subjectSyntaxTypesSupported.includes(SubjectIdentifierType.DID);
+      if (
+        subjectSyntaxTypesSupported.length ===
+        subjectSyntaxTypesSupported.filter(
+          (sst) => sst.includes(SubjectSyntaxTypesSupportedValues.DID.valueOf()) || sst === SubjectSyntaxTypesSupportedValues.JWK_THUMBPRINT.valueOf()
+        ).length
+      ) {
+        return true;
+      }
     }
   }
   return false;
 }
 
-function supportedDidMethods(rpMethods: string[] | string, opMethods: string[] | string): Array<string> {
-  const supportedDidMethods = getIntersection(rpMethods, opMethods);
-  if (!supportedDidMethods.length || (supportedDidMethods.length === 1 && supportedDidMethods[0] === SubjectIdentifierType.DID)) {
+function supportedSubjectSyntaxTypes(rpMethods: string[] | string, opMethods: string[] | string): Array<string> {
+  const rpMethodsList = Array.isArray(rpMethods) ? rpMethods : [rpMethods];
+  const opMethodsList = Array.isArray(opMethods) ? opMethods : [opMethods];
+  const supportedSubjectSyntaxTypes = getIntersection(rpMethodsList, opMethodsList);
+  if (supportedSubjectSyntaxTypes.indexOf(SubjectSyntaxTypesSupportedValues.DID.valueOf()) !== -1) {
+    return [SubjectSyntaxTypesSupportedValues.DID.valueOf()];
+  }
+  if (rpMethodsList.includes(SubjectSyntaxTypesSupportedValues.DID.valueOf())) {
+    const supportedExtendedDids: string[] = opMethodsList.filter((method) => method.startsWith('did:'));
+    if (supportedExtendedDids.length) {
+      return supportedExtendedDids;
+    }
+  }
+  if (opMethodsList.includes(SubjectSyntaxTypesSupportedValues.DID.valueOf())) {
+    const supportedExtendedDids: string[] = rpMethodsList.filter((method) => method.startsWith('did:'));
+    if (supportedExtendedDids.length) {
+      return supportedExtendedDids;
+    }
+  }
+
+  if (!supportedSubjectSyntaxTypes.length) {
     throw Error(SIOPErrors.DID_METHODS_NOT_SUPORTED);
   }
-  return supportedDidMethods;
+  const supportedDidMethods = supportedSubjectSyntaxTypes.filter((sst) => sst.includes('did:'));
+  if (supportedDidMethods.length) {
+    return supportedDidMethods;
+  }
+  return supportedSubjectSyntaxTypes;
 }
 
 function getFormatIntersection(rpFormat: Format, opFormat: Format) {

--- a/src/main/functions/HttpUtils.ts
+++ b/src/main/functions/HttpUtils.ts
@@ -20,12 +20,10 @@ export async function postWithBearerToken(url: string, body: JWTPayload, bearerT
   }
 }
 
-// TODO SK Can you please put some documentation on it?
 export async function postAuthenticationResponse(url: string, body: AuthenticationResponseWithJWT): Promise<Response> {
   return postAuthenticationResponseJwt(url, body.jwt);
 }
 
-// TODO SK Can you please put some documentation on it?
 export async function postAuthenticationResponseJwt(url: string, jwt: string): Promise<Response> {
   try {
     const response = await fetch(url, {

--- a/src/main/functions/LinkedDomainValidations.ts
+++ b/src/main/functions/LinkedDomainValidations.ts
@@ -9,7 +9,7 @@ import {
 import { CheckLinkedDomain, DIDDocument } from '../types';
 
 import { resolveDidDocument } from './DIDResolution';
-import { getMethodFromDid } from './DidJWT';
+import { getMethodFromDid, toSIOPRegistrationDidMethod } from './DidJWT';
 
 function getValidationErrorMessages(validationResult: IDomainLinkageValidation): string[] {
   const messages = [];
@@ -57,7 +57,7 @@ function checkInvalidMessages(validationErrorMessages: string[]): { status: bool
 }
 
 export async function validateLinkedDomainWithDid(did: string, checkLinkedDomain: CheckLinkedDomain) {
-  const didDocument = await resolveDidDocument(did, { subjectSyntaxTypesSupported: [getMethodFromDid(did)] });
+  const didDocument = await resolveDidDocument(did, { subjectSyntaxTypesSupported: [toSIOPRegistrationDidMethod(getMethodFromDid(did))] });
   try {
     const validationResult = await checkWellknownDid(didDocument);
     if (validationResult.status === ValidationStatusEnum.INVALID) {

--- a/src/main/functions/LinkedDomainValidations.ts
+++ b/src/main/functions/LinkedDomainValidations.ts
@@ -9,7 +9,6 @@ import {
 import { CheckLinkedDomain, DIDDocument } from '../types';
 
 import { resolveDidDocument } from './DIDResolution';
-import { getMethodFromDid } from './DidJWT';
 
 function getValidationErrorMessages(validationResult: IDomainLinkageValidation): string[] {
   const messages = [];
@@ -57,7 +56,7 @@ function checkInvalidMessages(validationErrorMessages: string[]): { status: bool
 }
 
 export async function validateLinkedDomainWithDid(did: string, checkLinkedDomain: CheckLinkedDomain) {
-  const didDocument = await resolveDidDocument(did, { subjectSyntaxTypesSupported: [getMethodFromDid(did)] });
+  const didDocument = await resolveDidDocument(did, { subjectSyntaxTypesSupported: ['did'] });
   try {
     const validationResult = await checkWellknownDid(didDocument);
     if (validationResult.status === ValidationStatusEnum.INVALID) {

--- a/src/main/functions/LinkedDomainValidations.ts
+++ b/src/main/functions/LinkedDomainValidations.ts
@@ -9,6 +9,7 @@ import {
 import { CheckLinkedDomain, DIDDocument } from '../types';
 
 import { resolveDidDocument } from './DIDResolution';
+import { getMethodFromDid } from './DidJWT';
 
 function getValidationErrorMessages(validationResult: IDomainLinkageValidation): string[] {
   const messages = [];
@@ -56,7 +57,7 @@ function checkInvalidMessages(validationErrorMessages: string[]): { status: bool
 }
 
 export async function validateLinkedDomainWithDid(did: string, checkLinkedDomain: CheckLinkedDomain) {
-  const didDocument = await resolveDidDocument(did, { subjectSyntaxTypesSupported: ['did'] });
+  const didDocument = await resolveDidDocument(did, { subjectSyntaxTypesSupported: [getMethodFromDid(did)] });
   try {
     const validationResult = await checkWellknownDid(didDocument);
     if (validationResult.status === ValidationStatusEnum.INVALID) {

--- a/src/main/types/Errors.ts
+++ b/src/main/types/Errors.ts
@@ -34,6 +34,7 @@ enum SIOPErrors {
   NO_KEY_CURVE_SUPPORTED = 'Key Curve not supported.',
   NO_NONCE = 'No nonce found in JWT payload',
   NO_REFERENCE_URI = 'referenceUri must be defined when REFERENCE option is used',
+  NO_DID_METHOD_FOUND = 'No did method found.',
   NO_SELFISSUED_ISS = 'The Response Token Issuer Claim (iss) MUST be https://self-isued.me',
   NO_SUB_TYPE = 'No or empty sub_type found in JWT payload',
   REGISTRATION_NOT_SET = 'Registration metadata not set.',

--- a/src/main/types/SIOP.types.ts
+++ b/src/main/types/SIOP.types.ts
@@ -463,12 +463,10 @@ export type InternalVerification = Verification;
 export interface ExternalVerification extends Verification {
   verifyUri: string; // url to call to verify the id_token signature
   authZToken?: string; // Optional: bearer token to use to the call
-  resolveOpts: ResolveOpts;
 }
 
 export interface VerifyAuthenticationRequestOpts {
   verification: InternalVerification | ExternalVerification; // To use internal verification or external hosted verification
-  checkLinkedDomain?: CheckLinkedDomain;
   // didDocument?: DIDDocument; // If not provided the DID document will be resolved from the request
   nonce?: string; // If provided the nonce in the request needs to match
   // redirectUri?: string;
@@ -476,7 +474,6 @@ export interface VerifyAuthenticationRequestOpts {
 
 export interface VerifyAuthenticationResponseOpts {
   verification: InternalVerification | ExternalVerification;
-  checkLinkedDomain?: CheckLinkedDomain;
   // didDocument?: DIDDocument; // If not provided the DID document will be resolved from the request
   nonce?: string; // mandatory? // To verify the response against the supplied nonce
   state?: string; // mandatory? // To verify the response against the supplied state

--- a/src/main/types/SIOP.types.ts
+++ b/src/main/types/SIOP.types.ts
@@ -591,6 +591,11 @@ export enum SubjectIdentifierType {
   DID = 'did',
 }
 
+export enum SubjectSyntaxTypesSupportedValues {
+  DID = 'did',
+  JWK_THUMBPRINT = 'urn:ietf:params:oauth:jwk-thumbprint',
+}
+
 export enum CredentialFormat {
   JSON_LD = 'w3cvc-jsonld',
   JWT = 'jwt',

--- a/src/main/types/SIOP.types.ts
+++ b/src/main/types/SIOP.types.ts
@@ -92,7 +92,7 @@ export interface AuthenticationResponsePayload extends JWTPayload {
   iss: ResponseIss.SELF_ISSUED_V2 | string; // The SIOP V2 spec mentions this is required, but current implementations use the kid/did here
   sub: string; // did (or thumbprint of sub_jwk key when type is jkt)
   // sub_type: SubjectIdentifierType;
-  sub_jwk: JWK;
+  sub_jwk?: JWK;
   aud: string; // redirect_uri from request
   exp: number; // Expiration time
   iat: number; // Issued at time

--- a/src/main/types/SSI.types.ts
+++ b/src/main/types/SSI.types.ts
@@ -3,6 +3,7 @@ import { JWK } from 'jose';
 
 export interface ResolveOpts {
   resolver?: Resolvable;
+  //TODO: fix it in VDX-139
   resolvers?: Map<string, Resolvable>;
   resolveUrl?: string;
   subjectSyntaxTypesSupported?: string[];

--- a/src/main/types/SSI.types.ts
+++ b/src/main/types/SSI.types.ts
@@ -3,6 +3,7 @@ import { JWK } from 'jose';
 
 export interface ResolveOpts {
   resolver?: Resolvable;
+  resolvers?: Map<string, Resolvable>;
   resolveUrl?: string;
   subjectSyntaxTypesSupported?: string[];
 }

--- a/test/AuthenticationRequest.verify.spec.ts
+++ b/test/AuthenticationRequest.verify.spec.ts
@@ -79,7 +79,7 @@ describe('SIOP Request Validation', () => {
       verification: {
         mode: VerificationMode.INTERNAL,
         resolveOpts: {
-          subjectSyntaxTypesSupported: ['ethr'],
+          subjectSyntaxTypesSupported: ['did:ethr'],
         },
       },
     };
@@ -192,7 +192,7 @@ describe('verifyJWT should', () => {
       verification: {
         mode: VerificationMode.INTERNAL,
         resolveOpts: {
-          subjectSyntaxTypesSupported: ['ethr'],
+          subjectSyntaxTypesSupported: ['did:ethr'],
         },
       },
     };

--- a/test/AuthenticationRequest.verify.spec.ts
+++ b/test/AuthenticationRequest.verify.spec.ts
@@ -16,7 +16,7 @@ import {
   ResponseType,
   Scope,
   SigningAlgo,
-  SubjectIdentifierType,
+  SubjectSyntaxTypesSupportedValues,
   SubjectType,
   VerificationMode,
   VerifyAuthenticationRequestOpts,
@@ -58,7 +58,7 @@ describe('SIOP Request Validation', () => {
         request_object_signing_alg_values_supported: [SigningAlgo.EDDSA, SigningAlgo.ES256K],
         response_types_supported: [ResponseType.ID_TOKEN],
         scopes_supported: [Scope.OPENID],
-        subject_syntax_types_supported: ['did:ethr:', SubjectIdentifierType.DID],
+        subject_syntax_types_supported: ['did:ethr:', SubjectSyntaxTypesSupportedValues.DID],
         subject_types_supported: [SubjectType.PAIRWISE],
         vp_formats: {
           ldp_vc: {
@@ -126,7 +126,7 @@ describe('verifyJWT should', () => {
         subjectTypesSupported: [SubjectType.PAIRWISE],
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256K],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256K],
-        subjectSyntaxTypesSupported: ['did:ethr:', SubjectIdentifierType.DID],
+        subjectSyntaxTypesSupported: ['did:ethr:', SubjectSyntaxTypesSupportedValues.DID],
         vpFormatsSupported: {
           ldp_vc: {
             proof_type: [IProofType.EcdsaSecp256k1Signature2019, IProofType.EcdsaSecp256k1Signature2019],
@@ -212,7 +212,7 @@ describe('OP and RP communication should', () => {
           proof_type: ['EcdsaSecp256k1Signature2019', 'EcdsaSecp256k1Signature2019'],
         },
       },
-      subject_syntax_types_supported: [SubjectIdentifierType.DID, 'did:web'],
+      subject_syntax_types_supported: ['did:web'],
     });
   });
 
@@ -222,9 +222,9 @@ describe('OP and RP communication should', () => {
         proof_type: [IProofType.EcdsaSecp256k1Signature2019, IProofType.EcdsaSecp256k1Signature2019],
       },
     };
-    metadata.rpMetadata.subject_syntax_types_supported = ['did:web', SubjectIdentifierType.DID];
+    metadata.rpMetadata.subject_syntax_types_supported = ['did:web'];
     expect(metadata.verify()).toEqual({
-      subject_syntax_types_supported: ['did:web', SubjectIdentifierType.DID],
+      subject_syntax_types_supported: ['did:web'],
       vp_formats: {
         ldp_vc: {
           proof_type: ['EcdsaSecp256k1Signature2019', 'EcdsaSecp256k1Signature2019'],
@@ -240,7 +240,6 @@ describe('OP and RP communication should', () => {
       },
     };
     const result = metadata.verify();
-    expect(result['subject_syntax_types_supported']).toContain(SubjectIdentifierType.DID);
     expect(result['subject_syntax_types_supported']).toContain('did:web');
     expect(result['vp_formats']).toStrictEqual({
       ldp_vc: {
@@ -250,7 +249,7 @@ describe('OP and RP communication should', () => {
   });
 
   it('not work if RP does not support any OP did method', () => {
-    metadata.rpMetadata.subject_syntax_types_supported = ['did:notsupported:', SubjectIdentifierType.DID];
+    metadata.rpMetadata.subject_syntax_types_supported = ['did:notsupported'];
     expect(() => metadata.verify()).toThrowError(SIOPErrors.DID_METHODS_NOT_SUPORTED);
   });
 

--- a/test/AuthenticationResponse.response.spec.ts
+++ b/test/AuthenticationResponse.response.spec.ts
@@ -65,7 +65,7 @@ describe('create JWT from Request JWT should', () => {
   const verifyOpts: VerifyAuthenticationRequestOpts = {
     verification: {
       resolveOpts: {
-        subjectSyntaxTypesSupported: ['ethr'],
+        subjectSyntaxTypesSupported: ['did:ethr'],
       },
       mode: VerificationMode.INTERNAL,
     },

--- a/test/AuthenticationResponse.verify.spec.ts
+++ b/test/AuthenticationResponse.verify.spec.ts
@@ -12,7 +12,7 @@ describe('verify JWT from Request JWT should', () => {
     audience: DID,
     verification: {
       resolveOpts: {
-        subjectSyntaxTypesSupported: ['ethr'],
+        subjectSyntaxTypesSupported: ['did:ethr'],
       },
       mode: VerificationMode.INTERNAL,
     },

--- a/test/IT.spec.ts
+++ b/test/IT.spec.ts
@@ -114,7 +114,7 @@ describe('RP and OP interaction should', () => {
       .requestBy(PassBy.REFERENCE, EXAMPLE_REFERENCE_URL)
       .addIssuer(ResponseIss.SELF_ISSUED_V2)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, `${rpMockEntity.did}#controller`)
-      .addDidMethod('ethr')
+      .addDidMethod('did:ethr')
       .registrationBy({
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
@@ -128,7 +128,6 @@ describe('RP and OP interaction should', () => {
       .build();
     const op = OP.builder()
       .withExpiresIn(1000)
-      .addDidMethod('ethr')
       .addIssuer(ResponseIss.SELF_ISSUED_V2)
       .internalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, `${opMockEntity.did}#controller`)
       .registrationBy({
@@ -140,7 +139,7 @@ describe('RP and OP interaction should', () => {
         vpFormats: { jwt_vc: { alg: [KeyAlgo.EDDSA] } },
         scopesSupported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],
         subjectTypesSupported: [SubjectType.PAIRWISE],
-        subjectSyntaxTypesSupported: [],
+        subjectSyntaxTypesSupported: ['did:ethr'],
         registrationBy: { type: PassBy.VALUE },
       })
       .build();
@@ -187,7 +186,7 @@ describe('RP and OP interaction should', () => {
       .redirect(EXAMPLE_REDIRECT_URL)
       .requestBy(PassBy.VALUE)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey)
-      .addDidMethod('ethr')
+      .addDidMethod('did:ethr')
       .registrationBy({
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
@@ -201,7 +200,7 @@ describe('RP and OP interaction should', () => {
       .build();
     const op = OP.builder()
       .withExpiresIn(1000)
-      .addDidMethod('ethr')
+      .addDidMethod('did:ethr')
       .internalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey)
       .registrationBy({
         authorizationEndpoint: 'www.myauthorizationendpoint.com',
@@ -261,7 +260,7 @@ describe('RP and OP interaction should', () => {
       .redirect(EXAMPLE_REDIRECT_URL)
       .requestBy(PassBy.VALUE)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey)
-      .addDidMethod('ethr')
+      .addDidMethod('did:ethr')
       .registrationBy({
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
@@ -279,7 +278,7 @@ describe('RP and OP interaction should', () => {
       .build();
     const op = OP.builder()
       .withExpiresIn(1000)
-      .addDidMethod('ethr')
+      .addDidMethod('did:ethr')
       .internalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey)
       .registrationBy({
         authorizationEndpoint: 'www.myauthorizationendpoint.com',
@@ -332,7 +331,7 @@ describe('RP and OP interaction should', () => {
       .requestBy(PassBy.VALUE)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey)
       .withAuthorizationEndpoint('www.myauthorizationendpoint.com')
-      .addDidMethod('ethr')
+      .addDidMethod('did:ethr')
       .registrationBy({
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
@@ -350,7 +349,7 @@ describe('RP and OP interaction should', () => {
       .build();
     const op = OP.builder()
       .withExpiresIn(1000)
-      .addDidMethod('ethr')
+      .addDidMethod('did:ethr')
       .internalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey)
       .registrationBy({
         authorizationEndpoint: 'www.myauthorizationendpoint.com',

--- a/test/IT.spec.ts
+++ b/test/IT.spec.ts
@@ -114,7 +114,7 @@ describe('RP and OP interaction should', () => {
       .requestBy(PassBy.REFERENCE, EXAMPLE_REFERENCE_URL)
       .addIssuer(ResponseIss.SELF_ISSUED_V2)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, `${rpMockEntity.did}#controller`)
-      .addDidMethod('did:ethr')
+      .addDidMethod('ethr')
       .registrationBy({
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
@@ -186,7 +186,7 @@ describe('RP and OP interaction should', () => {
       .redirect(EXAMPLE_REDIRECT_URL)
       .requestBy(PassBy.VALUE)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey)
-      .addDidMethod('did:ethr')
+      .addDidMethod('ethr')
       .registrationBy({
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
@@ -200,7 +200,7 @@ describe('RP and OP interaction should', () => {
       .build();
     const op = OP.builder()
       .withExpiresIn(1000)
-      .addDidMethod('did:ethr')
+      .addDidMethod('ethr')
       .internalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey)
       .registrationBy({
         authorizationEndpoint: 'www.myauthorizationendpoint.com',
@@ -260,7 +260,7 @@ describe('RP and OP interaction should', () => {
       .redirect(EXAMPLE_REDIRECT_URL)
       .requestBy(PassBy.VALUE)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey)
-      .addDidMethod('did:ethr')
+      .addDidMethod('ethr')
       .registrationBy({
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
@@ -278,7 +278,7 @@ describe('RP and OP interaction should', () => {
       .build();
     const op = OP.builder()
       .withExpiresIn(1000)
-      .addDidMethod('did:ethr')
+      .addDidMethod('ethr')
       .internalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey)
       .registrationBy({
         authorizationEndpoint: 'www.myauthorizationendpoint.com',
@@ -331,7 +331,7 @@ describe('RP and OP interaction should', () => {
       .requestBy(PassBy.VALUE)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey)
       .withAuthorizationEndpoint('www.myauthorizationendpoint.com')
-      .addDidMethod('did:ethr')
+      .addDidMethod('ethr')
       .registrationBy({
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
@@ -349,7 +349,7 @@ describe('RP and OP interaction should', () => {
       .build();
     const op = OP.builder()
       .withExpiresIn(1000)
-      .addDidMethod('did:ethr')
+      .addDidMethod('ethr')
       .internalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey)
       .registrationBy({
         authorizationEndpoint: 'www.myauthorizationendpoint.com',
@@ -617,7 +617,7 @@ describe('RP and OP interaction should', () => {
       .requestBy(PassBy.VALUE)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey)
       .withAuthorizationEndpoint('www.myauthorizationendpoint.com')
-      .addDidMethod('did:ethr')
+      .addDidMethod('ethr')
       .registrationBy({
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
@@ -636,7 +636,7 @@ describe('RP and OP interaction should', () => {
     const op = OP.builder()
       .withCheckLinkedDomain(CheckLinkedDomain.NEVER)
       .withExpiresIn(1000)
-      .addDidMethod('did:ethr')
+      .addDidMethod('ethr')
       .internalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey)
       .registrationBy({
         authorizationEndpoint: 'www.myauthorizationendpoint.com',

--- a/test/IT.spec.ts
+++ b/test/IT.spec.ts
@@ -423,7 +423,6 @@ describe('RP and OP interaction should', () => {
       .requestBy(PassBy.VALUE)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey)
       .withAuthorizationEndpoint('www.myauthorizationendpoint.com')
-      .addDidMethod('ethr')
       .registrationBy({
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
@@ -441,7 +440,6 @@ describe('RP and OP interaction should', () => {
       .build();
     const op = OP.builder()
       .withExpiresIn(1000)
-      .addDidMethod('ethr')
       .internalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey)
       .registrationBy({
         authorizationEndpoint: 'www.myauthorizationendpoint.com',
@@ -452,7 +450,7 @@ describe('RP and OP interaction should', () => {
         vpFormats: { jwt_vc: { alg: [KeyAlgo.EDDSA] } },
         scopesSupported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],
         subjectTypesSupported: [SubjectType.PAIRWISE],
-        subjectSyntaxTypesSupported: [],
+        subjectSyntaxTypesSupported: ['did'],
         registrationBy: { type: PassBy.VALUE },
       })
       .build();
@@ -513,7 +511,6 @@ describe('RP and OP interaction should', () => {
       .requestBy(PassBy.VALUE)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey)
       .withAuthorizationEndpoint('www.myauthorizationendpoint.com')
-      .addDidMethod('ion')
       .registrationBy({
         idTokenSigningAlgValuesSupported: [SigningAlgo.ES256K],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.ES256K],
@@ -536,7 +533,6 @@ describe('RP and OP interaction should', () => {
       .build();
     const op = OP.builder()
       .withExpiresIn(1000)
-      .addDidMethod('ethr')
       .internalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey)
       .registrationBy({
         authorizationEndpoint: 'www.myauthorizationendpoint.com',
@@ -552,7 +548,7 @@ describe('RP and OP interaction should', () => {
         },
         scopesSupported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],
         subjectTypesSupported: [SubjectType.PAIRWISE],
-        subjectSyntaxTypesSupported: [],
+        subjectSyntaxTypesSupported: ['did:ethr'],
         registrationBy: { type: PassBy.VALUE },
       })
       .build();
@@ -622,7 +618,7 @@ describe('RP and OP interaction should', () => {
       .requestBy(PassBy.VALUE)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, rpMockEntity.didKey)
       .withAuthorizationEndpoint('www.myauthorizationendpoint.com')
-      .addDidMethod('ethr')
+      .addDidMethod('did:ethr')
       .registrationBy({
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
@@ -641,7 +637,7 @@ describe('RP and OP interaction should', () => {
     const op = OP.builder()
       .withCheckLinkedDomain(CheckLinkedDomain.NEVER)
       .withExpiresIn(1000)
-      .addDidMethod('ethr')
+      .addDidMethod('did:ethr')
       .internalSignature(opMockEntity.hexPrivateKey, opMockEntity.did, opMockEntity.didKey)
       .registrationBy({
         authorizationEndpoint: 'www.myauthorizationendpoint.com',

--- a/test/OP.request.spec.ts
+++ b/test/OP.request.spec.ts
@@ -86,7 +86,7 @@ describe('OP should', () => {
     verification: {
       mode: VerificationMode.INTERNAL,
       resolveOpts: {
-        subjectSyntaxTypesSupported: ['ethr'],
+        subjectSyntaxTypesSupported: ['did:ethr'],
       },
     },
     nonce: 'qBrR7mqnY3Qr49dAZycPF8FzgE83m6H0c2l0bzP4xSg',
@@ -119,7 +119,7 @@ describe('OP should', () => {
       },
       registration: {
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
-        subjectSyntaxTypesSupported: ['did:ethr:', SubjectIdentifierType.DID],
+        subjectSyntaxTypesSupported: ['did:ethr', SubjectIdentifierType.DID],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
         responseTypesSupported: [ResponseType.ID_TOKEN],
         scopesSupported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],

--- a/test/OP.request.spec.ts
+++ b/test/OP.request.spec.ts
@@ -157,7 +157,7 @@ describe('OP should', () => {
 
     const requestURI = await RP.builder()
       .withCheckLinkedDomain(CheckLinkedDomain.NEVER)
-      .withAuthorizationEndpoint('www.muauthorizationendpoint.com')
+      .withAuthorizationEndpoint('www.myauthorizationendpoint.com')
       .redirect(EXAMPLE_REFERENCE_URL)
       .requestBy(PassBy.REFERENCE, EXAMPLE_REFERENCE_URL)
       .internalSignature(rpMockEntity.hexPrivateKey, rpMockEntity.did, `${rpMockEntity.did}#controller`)

--- a/test/RP.request.spec.ts
+++ b/test/RP.request.spec.ts
@@ -73,7 +73,7 @@ describe('RP should', () => {
       },
       registration: {
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
-        subjectSyntaxTypesSupported: ['did:ethr:', SubjectIdentifierType.DID],
+        subjectSyntaxTypesSupported: ['did:ethr', SubjectIdentifierType.DID],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
         responseTypesSupported: [ResponseType.ID_TOKEN],
         scopesSupported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],
@@ -108,7 +108,7 @@ describe('RP should', () => {
       },
       registration: {
         idTokenSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
-        subjectSyntaxTypesSupported: ['did:ethr:', SubjectIdentifierType.DID],
+        subjectSyntaxTypesSupported: ['did:ethr', SubjectIdentifierType.DID],
         requestObjectSigningAlgValuesSupported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
         responseTypesSupported: [ResponseType.ID_TOKEN],
         scopesSupported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],
@@ -140,7 +140,7 @@ describe('RP should', () => {
         request_object_signing_alg_values_supported: [SigningAlgo.EDDSA, SigningAlgo.ES256],
         response_types_supported: [ResponseType.ID_TOKEN],
         scopes_supported: [Scope.OPENID_DIDAUTHN, Scope.OPENID],
-        subject_syntax_types_supported: ['did:ethr:', 'did'],
+        subject_syntax_types_supported: ['did:ethr', 'did'],
         subject_types_supported: [SubjectType.PAIRWISE],
         vp_formats: {
           jwt: {
@@ -159,11 +159,11 @@ describe('RP should', () => {
       '3Qr49dAZycPF8FzgE83m6H0c2l0bzP4xSg&state=b32f0087fc9816eb813fd11f&registration=%7B%22id_token_signing_alg_values_supported%22%3A%5B%22' +
       'EdDSA%22%2C%22ES256%22%5D%2C%22request_object_signing_alg_values_supported%22%3A%5B%22EdDSA%22%2C%22ES256%22%5D%2C%22response_types_su' +
       'pported%22%3A%5B%22id_token%22%5D%2C%22scopes_supported%22%3A%5B%22openid%20did_authn%22%2C%22openid%22%5D%2C%22subject_types_supporte' +
-      'd%22%3A%5B%22pairwise%22%5D%2C%22subject_syntax_types_supported%22%3A%5B%22did%3Aethr%3A%22%2C%22did%22%5D%2C%22vp_formats%22%3A%7B%22' +
-      'jwt_vc%22%3A%7B%22alg%22%3A%5B%22EdDSA%22%2C%22ES256K%22%2C%22ES256%22%5D%7D%2C%22jwt_vp%22%3A%7B%22alg%22%3A%5B%22EdDSA%22%2C%22ES256' +
-      'K%22%2C%22ES256%22%5D%7D%2C%22jwt%22%3A%7B%22alg%22%3A%5B%22EdDSA%22%2C%22ES256K%22%2C%22ES256%22%5D%7D%2C%22ldp_vc%22%3A%7B%22proof_t' +
-      'ype%22%3A%5B%22EcdsaSecp256k1Signature2019%22%2C%22EcdsaSecp256k1Signature2019%22%5D%7D%7D%7D&request_uri=https%3A%2F%2Frp.acme.com%2F' +
-      'siop%2Fjwts';
+      'd%22%3A%5B%22pairwise%22%5D%2C%22subject_syntax_types_supported%22%3A%5B%22did%3Aethr%22%2C%22did%22%5D%2C%22vp_formats%22%3A%7B%22jwt' +
+      '_vc%22%3A%7B%22alg%22%3A%5B%22EdDSA%22%2C%22ES256K%22%2C%22ES256%22%5D%7D%2C%22jwt_vp%22%3A%7B%22alg%22%3A%5B%22EdDSA%22%2C%22ES256K%2' +
+      '2%2C%22ES256%22%5D%7D%2C%22jwt%22%3A%7B%22alg%22%3A%5B%22EdDSA%22%2C%22ES256K%22%2C%22ES256%22%5D%7D%2C%22ldp_vc%22%3A%7B%22proof_type' +
+      '%22%3A%5B%22EcdsaSecp256k1Signature2019%22%2C%22EcdsaSecp256k1Signature2019%22%5D%7D%7D%7D&request_uri=https%3A%2F%2Frp.acme.com%2Fsio' +
+      'p%2Fjwts';
     const expectedJwtRegex =
       /^eyJhbGciOiJFUzI1NksiLCJraWQiOiJkaWQ6ZXRocjoweDAxMDZhMmU5ODViMUUxRGU5QjVkZGI0YUY2ZEM5ZTkyOEY0ZTk5RDAja2V5cy0xIiwidHlwIjoiSldUIn0\.ey.*$/;
 
@@ -241,7 +241,7 @@ describe('RP should', () => {
         subjectSyntaxTypesSupported: [],
         registrationBy: { type: PassBy.VALUE },
       })
-      .addDidMethod('did:ethr')
+      .addDidMethod('did:ethr:')
       .build()
 
       .createAuthenticationRequest({

--- a/test/RP.request.spec.ts
+++ b/test/RP.request.spec.ts
@@ -34,7 +34,7 @@ describe('RP Builder should', () => {
     expect(
       RP.builder()
         .withCheckLinkedDomain(CheckLinkedDomain.NEVER)
-        .addDidMethod('factom')
+        .addDidMethod('did:factom')
         .addResolver('ethr', new Resolver(getUniResolver('ethr')))
         .redirect('https://redirect.me')
         .requestBy(PassBy.VALUE)
@@ -241,7 +241,7 @@ describe('RP should', () => {
         subjectSyntaxTypesSupported: [],
         registrationBy: { type: PassBy.VALUE },
       })
-      .addDidMethod('ethr')
+      .addDidMethod('did:ethr')
       .build()
 
       .createAuthenticationRequest({

--- a/test/RP.request.spec.ts
+++ b/test/RP.request.spec.ts
@@ -34,7 +34,7 @@ describe('RP Builder should', () => {
     expect(
       RP.builder()
         .withCheckLinkedDomain(CheckLinkedDomain.NEVER)
-        .addDidMethod('did:factom')
+        .addDidMethod('factom')
         .addResolver('ethr', new Resolver(getUniResolver('ethr')))
         .redirect('https://redirect.me')
         .requestBy(PassBy.VALUE)
@@ -241,7 +241,7 @@ describe('RP should', () => {
         subjectSyntaxTypesSupported: [],
         registrationBy: { type: PassBy.VALUE },
       })
-      .addDidMethod('did:ethr:')
+      .addDidMethod('ethr')
       .build()
 
       .createAuthenticationRequest({

--- a/test/RP.request.spec.ts
+++ b/test/RP.request.spec.ts
@@ -241,7 +241,7 @@ describe('RP should', () => {
         subjectSyntaxTypesSupported: [],
         registrationBy: { type: PassBy.VALUE },
       })
-      .addDidMethod('ethr')
+      .addDidMethod('did:ethr')
       .build()
 
       .createAuthenticationRequest({

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -21,7 +21,7 @@ import {
   RPRegistrationMetadataPayload,
   Scope,
   SigningAlgo,
-  SubjectIdentifierType,
+  SubjectSyntaxTypesSupportedValues,
   SubjectType,
 } from '../src/main';
 import SIOPErrors from '../src/main/types/Errors';
@@ -227,7 +227,7 @@ export const metadata: {
   opMetadata: {
     issuer: ResponseIss.SELF_ISSUED_V2,
     authorization_endpoint: 'http://test.com',
-    subject_syntax_types_supported: ['did:web', SubjectIdentifierType.DID],
+    subject_syntax_types_supported: ['did:web'],
     id_token_signing_alg_values_supported: undefined,
     request_object_signing_alg_values_supported: [SigningAlgo.EDDSA],
     response_types_supported: ResponseType.ID_TOKEN,
@@ -247,7 +247,7 @@ export const metadata: {
     request_object_signing_alg_values_supported: [SigningAlgo.EDDSA],
     response_types_supported: [ResponseType.ID_TOKEN],
     scopes_supported: [Scope.OPENID, Scope.OPENID_DIDAUTHN],
-    subject_syntax_types_supported: [SubjectIdentifierType.DID, 'did:web', 'did:key'],
+    subject_syntax_types_supported: [SubjectSyntaxTypesSupportedValues.DID.valueOf(), 'did:web', 'did:key'],
     subject_types_supported: [SubjectType.PAIRWISE],
     vp_formats: {
       ldp_vc: {


### PR DESCRIPTION
updates:
- removed checkedLinkedDomain property from `VerifyAuthenticationResponseOpts` and `VerifyAuthenticationRequestOpts` because we are using it from `Internal/External Verification` object
- [if we don't pass a checkLinkedDomain option to our OP/RP it will use CheckLinkedDomain.IF_PRESENT
- fixed the logic behind finding intersection of OP & RP supported `subjectSyntaxTypes`
- added another enum for `SubjectSyntaxTypesSupportedValues` that has values of `did` and `urn:ietf:params:oauth:jwk-thumbprint`
- fixed the problem with handling the `subject_syntax_types` when OP/RP are initialized using `withDidMethod`
- fixed the problem with `nonce` value in populating `AuthenticationRequestPayload`
- fixed the tests with the correct logic of finding intersection of of OP & RP supported `subjectSyntaxTypes`